### PR TITLE
traefik: use new crd for tlsstore

### DIFF
--- a/k8s-home/traefik/default.tlsstore.yaml
+++ b/k8s-home/traefik/default.tlsstore.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: TLSStore
 metadata:
   name: default

--- a/k8s-prod-02/traefik/default.tlsstore.yaml
+++ b/k8s-prod-02/traefik/default.tlsstore.yaml
@@ -1,13 +1,12 @@
----
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: TLSStore
 metadata:
   name: default
   namespace: cert-manager
 spec:
   certificates:
-    - secretName: wildcard.frickel.earth-prod
-    - secretName: wildcard.k8s-prod-02.frickel.earth-prod
-    - secretName: siewert.io-prod
+  - secretName: wildcard.frickel.earth-prod
+  - secretName: wildcard.k8s-prod-02.frickel.earth-prod
+  - secretName: siewert.io-prod
   defaultCertificate:
     secretName: wildcard.k8s-prod-02.frickel.earth-prod


### PR DESCRIPTION
Traefik migrated its apiVersion from traefik.containo.us/v1alpha1 to
traefik.io/v1alpha1. There was a grace-period for the migration, but
I somehow missed it and well traefik went poof.